### PR TITLE
Config CMD implementation

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -10,18 +10,6 @@ import (
 // configCmd represents the config command
 var Cmd = &cobra.Command{
 	Use:   "config",
-	Short: "Mirroring options setup",
-	Long:  `Long description`,
-}
-
-func init() {
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// configCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// configCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	Short: "Ditto options setup",
+	Long:  `Gives ability to get value set for particular key. List all options, or change it.`,
 }

--- a/cmd/config/config_get.go
+++ b/cmd/config/config_get.go
@@ -8,39 +8,45 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"storj.io/ditto/cmd/config/config_utils"
 	"storj.io/ditto/pkg/config"
 )
 
 var getSubCmd = &cobra.Command{
-	Use:   "get",
-	Short: "Mirroring options setup",
-	Long:  `getSub`,
-
-	Run: func(cmd *cobra.Command, args []string) {
-		arg := args[0]
-
-		config.ReadDefaultConfig(false)
-		if config_utils.ContainsKey(arg) {
-			getValueFromConfigFile(arg)
-		} else {
-			fmt.Println("\tKey unsupported")
-		}
-	},
-
-	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) != 1 {
-			return errors.New("Only one argument accepted")
-		}
-		return nil
-	},
+	Use:   "get [key]",
+	Short: "Displays value set for requested key",
+	Long:  "Displays value set for requested key",
+	RunE:  executeGetCmd,
+	Args:  validateGetArgs,
 }
 
-func getValueFromConfigFile(key string) {
-	if viper.IsSet(key) {
-		fmt.Printf("\t%s\n", viper.GetString(key))
+// Method reference for unit testing
+var readConfigMethod = config.ReadConfig
+
+func executeGetCmd(cmd *cobra.Command, args []string) error {
+	arg := args[0]
+
+	readConfigMethod(false)
+	if containsKey(arg) {
+		fmt.Sprintf("\t%s\n", getValueFromConfigFile(arg))
+		return nil
 	} else {
-		fmt.Println("\tUNDEFINED")
+		return errors.New("Key unsupported")
+	}
+}
+
+func validateGetArgs(cmd *cobra.Command, args [] string) error {
+	if len(args) != 1 {
+		return errors.New("Only one argument accepted")
+	}
+	return nil
+
+}
+
+func getValueFromConfigFile(key string) string {
+	if viper.IsSet(key) {
+		return viper.GetString(key)
+	} else {
+		return "Key is not set"
 	}
 }
 

--- a/cmd/config/config_get_test.go
+++ b/cmd/config/config_get_test.go
@@ -1,0 +1,127 @@
+// Copyright (C) 2018 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package config
+
+import (
+	"github.com/magiconair/properties/assert"
+	"github.com/spf13/viper"
+	"go.etcd.io/etcd/pkg/testutil"
+	"storj.io/ditto/pkg/config"
+	"testing"
+)
+
+func TestValidateGetArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		err  string
+	}{
+		{
+			name: "Empy args",
+			args: []string{},
+			err:  "Only one argument accepted",
+		},
+		{
+			name: "Too many args",
+			args: []string{"a", "a"},
+			err:  "Only one argument accepted",
+		},
+		{
+			name: "Valid case",
+			args: []string{"a"},
+			err:  "",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateGetArgs(nil, test.args)
+
+			if test.err != "" {
+				assert.Equal(t, err.Error(), test.err)
+			}
+		})
+	}
+}
+
+func TestGetValueFromConfigFile(t *testing.T) {
+	tests := []struct {
+		name           string
+		key            string
+		viperInitFunc  func(useDefaults bool) (config *config.Config, err error)
+		expectedResult string
+	}{
+		{
+			name: "Key not set",
+			key:  "a",
+			viperInitFunc: func(useDefaults bool) (config *config.Config, err error) {
+				viper.Reset()
+				return nil, nil
+			},
+			expectedResult: "Key is not set",
+		},
+		{
+			name: "Key exist",
+			key:  "a",
+			viperInitFunc: func(useDefaults bool) (config *config.Config, err error) {
+				viper.Reset()
+				viper.Set("a", "b")
+				return nil, nil
+			},
+			expectedResult: "b",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			readConfigMethod = test.viperInitFunc
+			readConfigMethod(false)
+			value := getValueFromConfigFile(test.key)
+
+			assert.Equal(t, value, test.expectedResult)
+		})
+	}
+}
+
+func TestExecuteGetCmd(t *testing.T) {
+	tests := []struct {
+		name           string
+		viperInitFunc  func(useDefaults bool) (config *config.Config, err error)
+		args           []string
+		expectedResult string
+	}{
+		{
+			name:"Unsupported key",
+			viperInitFunc: func(useDefaults bool) (config *config.Config, err error) {
+				viper.Reset()
+
+				return nil, nil
+			},
+			args: []string{"a"},
+			expectedResult:"Key unsupported",
+		},
+		{
+			name:"Valid case",
+			viperInitFunc: func(useDefaults bool) (config *config.Config, err error) {
+				viper.Reset()
+				viper.Set("Server1.Endpoint", "b")
+				return nil, nil
+			},
+			args: []string{"Server1.Endpoint"},
+			expectedResult:"",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			readConfigMethod = test.viperInitFunc
+			err := executeGetCmd(nil, test.args)
+
+			if test.expectedResult == "" {
+				testutil.AssertNil(t, err)
+			} else {
+				assert.Equal(t, err.Error(), test.expectedResult)
+			}
+
+
+		})
+	}
+}

--- a/cmd/config/config_list.go
+++ b/cmd/config/config_list.go
@@ -11,14 +11,16 @@ import (
 
 var listSubCmd = &cobra.Command{
 	Use:   "list",
-	Short: "Mirroring options setup",
-	Long:  `listSub`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Options, which can be set via `config set`:")
-		for _, value := range config.GetKeysArray() {
-			fmt.Printf("\t%s\n", value)
-		}
-	},
+	Short: "Displays list of possible to change options",
+	Long:  "Displays list of possible to change options",
+	Run:   executeListCmd,
+}
+
+func executeListCmd(cmd *cobra.Command, args []string) {
+	fmt.Println("Options, which can be set via `config set`:")
+	for _, value := range config.GetKeysArray() {
+		fmt.Printf("\t%s\n", value)
+	}
 }
 
 func init() {

--- a/cmd/config/config_set.go
+++ b/cmd/config/config_set.go
@@ -5,16 +5,67 @@ package config
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"storj.io/ditto/pkg/config"
 )
 
 var setSubCmd = &cobra.Command{
-	Use:   "set",
-	Short: "Mirroring options setup",
-	Long:  `listSub`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("list_cmd sub cmd called")
-	},
+	Use:   "set [key] [value]",
+	Short: "Change value at saves it to config file",
+	Long:  "Change value at saves it to config file",
+	RunE:  executeSetCmd,
+	Args:  validateSetArgs,
+}
+
+var writeConfigMethod = writeConfig
+
+func executeSetCmd(cmd *cobra.Command, args []string) error {
+	if len(args) != 2 {
+		return errors.New("Two arguments expected")
+	}
+	possibleValues, exist := argsMap[args[0]]
+	if !exist {
+
+		return errors.New("Key is not exist")
+	}
+
+	if len(possibleValues) == 0 {
+		return writeConfigMethod(args[0], args[1])
+	} else {
+		return setPredefinedOptions(args[0], args[1], possibleValues)
+	}
+}
+
+func validateSetArgs(cmd *cobra.Command, args []string) error {
+	if len(args) != 2 {
+		return errors.New("Two arguments expected")
+	}
+
+	return nil
+}
+
+func setPredefinedOptions(key string, value string, possibleValues []string) error {
+	if contains(possibleValues, value) {
+		return writeConfigMethod(key, value)
+	} else {
+		return errors.New(fmt.Sprintf("Only these arguments accepted: %s", possibleValues))
+	}
+}
+
+func writeConfig(key string, value string) error {
+	config.ReadConfig(false)
+
+	viper.Set(key, value)
+
+	err := viper.WriteConfig()
+	if err != nil {
+		return err
+	}
+
+	return nil
+
 }
 
 func init() {

--- a/cmd/config/config_set_test.go
+++ b/cmd/config/config_set_test.go
@@ -1,0 +1,141 @@
+// Copyright (C) 2018 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package config
+
+import (
+	"github.com/stretchr/testify/assert"
+	"go.etcd.io/etcd/pkg/testutil"
+	"testing"
+)
+
+func TestValidateSetArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		err  string
+	}{
+		{
+			name: "Empy args",
+			args: []string{},
+			err:  "Two arguments expected",
+		},
+		{
+			name: "Too many args",
+			args: []string{"a", "a", "a"},
+			err:  "Two arguments expected",
+		},
+		{
+			name: "Valid case",
+			args: []string{"a", "a"},
+			err:  "",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateSetArgs(nil, test.args)
+
+			if test.err == "" {
+				testutil.AssertNil(t, err)
+			} else {
+				assert.Equal(t, err.Error(), test.err)
+			}
+		})
+	}
+}
+
+func TestExecuteSetCmd(t *testing.T) {
+	tests := []struct {
+		name          string
+		args          []string
+		expectedError string
+	}{
+		{
+			name: "Two arguments expected",
+			args: []string{
+				"a",
+			},
+			expectedError: "Two arguments expected",
+		},
+		{
+			name: "Key is not exist",
+			args: []string{
+				"a",
+				"a",
+			},
+			expectedError: "Key is not exist",
+		},
+		{
+			name: "Valid case for Credentials",
+			args: []string{
+				"Server1.Endpoint",
+				"testEndpoint",
+			},
+			expectedError: "",
+		},
+		{
+			name: "Valid case for Predefined options",
+			args: []string{
+				"DefaultOptions.DefaultSource",
+				"server1",
+			},
+			expectedError: "",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			writeConfigMethod = func(key string, value string) error {
+				return nil
+			}
+
+			err := executeSetCmd(nil, test.args)
+
+			if test.expectedError == "" {
+				assert.Nil(t, err)
+			} else {
+				assert.Equal(t, err.Error(), test.expectedError)
+			}
+
+		})
+	}
+}
+
+func TestSetPredefinedOptions(t *testing.T) {
+	tests := []struct {
+		name           string
+		key            string
+		value          string
+		possibleValues []string
+		expectedResult string
+	}{
+		{
+			name:           "Wrong arguments",
+			key:            "",
+			value:          "a",
+			possibleValues: []string{"b"},
+			expectedResult: "Only these arguments accepted: [b]",
+		},
+		{
+			name:           "Valid case",
+			key:            "a",
+			value:          "a",
+			possibleValues: []string{"a"},
+			expectedResult: "",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			writeConfigMethod = func(key string, value string) error {
+				return nil
+			}
+
+			err := setPredefinedOptions(test.key, test.value, test.possibleValues)
+
+			if test.expectedResult == "" {
+				testutil.AssertNil(t, err)
+			} else {
+				assert.Equal(t, err.Error(), test.expectedResult)
+			}
+		})
+	}
+}

--- a/cmd/config/set_args_map.go
+++ b/cmd/config/set_args_map.go
@@ -1,0 +1,29 @@
+// Copyright (C) 2018 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package config
+
+import "storj.io/ditto/pkg/config"
+
+var argsMap = map[string][]string{
+	config.SERVER_1_ENDPOINT:                 {},
+	config.SERVER_1_ACCESS_KEY:               {},
+	config.SERVER_1_SECRET_KEY:               {},
+	config.SERVER_2_ENDPOINT:                 {},
+	config.SERVER_2_ACCESS_KEY:               {},
+	config.SERVER_2_SECRET_KEY:               {},
+	config.DEFAULT_OPTIONS_DEFAULT_SOURCE:    {"server1", "server2"},
+	config.DEFAULT_OPTIONS_THROW_IMMEDIATELY: {"true", "false"},
+	config.LIST_DEFAULT_SOURCE:               {"server1", "server2"},
+	config.LIST_THROW_IMMEDIATELY:            {"true", "false"},
+	config.LIST_MERGE:                        {"true", "false"},
+	config.PUT_DEFAULT_SOURCE:                {"server1", "server2"},
+	config.PUT_THROW_IMMEDIATELY:             {"true", "false"},
+	config.PUT_CREATE_BUCKET_IF_NOT_EXIST:    {"true", "false"},
+	config.GET_OBJECT_DEFAULT_SOURCE:         {"server1", "server2"},
+	config.GET_OBJECT_THROW_IMMEDIATELY:      {"true", "false"},
+	config.COPY_DEFAULT_SOURCE:               {"server1", "server2"},
+	config.COPY_THROW_IMMEDIATELY:            {"true", "false"},
+	config.DELETE_DEFAULT_SOURCE:             {"server1", "server2"},
+	config.DELETE_THROW_IMMEDIATELY:          {"true", "false"},
+}

--- a/cmd/config/utils.go
+++ b/cmd/config/utils.go
@@ -1,13 +1,23 @@
 // Copyright (C) 2018 Storj Labs, Inc.
 // See LICENSE for copying information.
 
-package config_utils
+package config
 
 import "storj.io/ditto/pkg/config"
 
-func ContainsKey(key string) bool {
+func containsKey(key string) bool {
 	for _, value := range config.GetKeysArray() {
 		if value == key {
+			return true
+		}
+	}
+
+	return false
+}
+
+func contains(slice []string, item string) bool {
+	for _, v := range slice {
+		if v == item {
 			return true
 		}
 	}

--- a/cmd/config/utils_test.go
+++ b/cmd/config/utils_test.go
@@ -1,0 +1,78 @@
+// Copyright (C) 2018 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package config
+
+import (
+	"github.com/magiconair/properties/assert"
+	"testing"
+)
+
+func TestContainsKey(t *testing.T) {
+	tests := []struct {
+		name           string
+		key            string
+		expectedResult bool
+	}{
+		{
+			name:           "ValidCase",
+			key:            "ListOptions.DefaultOptions.DefaultSource",
+			expectedResult: true,
+		},
+		{
+			name:           "Key is not valid",
+			key:            "a",
+			expectedResult: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			contains := containsKey(test.key)
+
+			assert.Equal(t, contains, test.expectedResult)
+		})
+	}
+}
+
+func TestContains(t *testing.T) {
+	tests := []struct {
+		name           string
+		item           string
+		slice          []string
+		expectedResult bool
+	}{
+		{
+			name: "Empty slice",
+			item: "a",
+			slice: []string{
+
+			},
+			expectedResult: false,
+		},
+		{
+			name: "Empty item",
+			item: "",
+			slice: []string{
+				"a",
+				"b",
+			},
+			expectedResult: false,
+		},
+		{
+			name: "Valid case",
+			item: "a",
+			slice: []string{
+				"a",
+				"b",
+			},
+			expectedResult: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			contains := contains(test.slice, test.item)
+
+			assert.Equal(t, contains, test.expectedResult)
+		})
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,13 +28,10 @@ var rootCmd = &cobra.Command{
 	Use:   "ditto",
 	Short: "A backup mirroring util",
 	Long:  `A backup mirroring util`,
-	// Uncomment the following line if your bare application
-	// has an action associated with it:
-	// 	Run: func(cmd *cobra.Command, args []string) { },
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
-// This is called by main.main(). It only needs to happen once to the rootCmd.
+// This is called by main.main(). It only needs to happen once to the RootCmd.
 func Execute() {
 	addCommands()
 	rootCmd.Execute()
@@ -55,13 +52,7 @@ func addCommands() {
 func init() {
 	cobra.OnInitialize(initConfig)
 
-	// Here you will define your flags and configuration settings.
-	// Cobra supports persistent flags, which, if defined here,
-	// will be global for your application.
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.mirroring/config.json)")
-
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }
 

--- a/cmd/utils/fileUtils.go
+++ b/cmd/utils/fileUtils.go
@@ -30,7 +30,7 @@ func FileOrDirExists(path string) (bool, error) {
 
 //TODO: implement
 func GetObjectLayer() (minio.ObjectLayer, error) {
-	defaultConfig, err := config.ReadDefaultConfig(true)
+	defaultConfig, err := config.ReadConfig(true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -323,7 +323,6 @@ func TestGetMergedPrimeCredentials(t *testing.T) {
 	}
 }
 
-
 func TestGetMergedAlterCredentials(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -368,6 +367,54 @@ func TestGetMergedAlterCredentials(t *testing.T) {
 			assert.Equal(t, credentials.Endpoint, test.expected.Endpoint)
 			assert.Equal(t, credentials.AccessKey, test.expected.AccessKey)
 			assert.Equal(t, credentials.SecretKey, test.expected.SecretKey)
+		})
+	}
+}
+
+func Test(t *testing.T) {
+	tests := []struct {
+		name           string
+		endpoint       string
+		accessKey      string
+		secretKey      string
+		expectedResult bool
+	}{
+		{
+			name:           "Empty endpoint",
+			endpoint:       "",
+			accessKey:      "a",
+			secretKey:      "a",
+			expectedResult: true,
+		},
+		{
+			name:           "Empty AccessKey",
+			endpoint:       "a",
+			accessKey:      "",
+			secretKey:      "a",
+			expectedResult: true,
+		},
+		{
+			name:           "Empty SecretKey",
+			endpoint:       "a",
+			accessKey:      "a",
+			secretKey:      "",
+			expectedResult: true,
+		},
+		{
+			name:           "Valid case",
+			endpoint:       "a",
+			accessKey:      "a",
+			secretKey:      "a",
+			expectedResult: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cred := NewCredentials(test.endpoint, test.accessKey, test.secretKey)
+
+			isEmpty := cred.IsEmpty()
+
+			assert.Equal(t, isEmpty, test.expectedResult)
 		})
 	}
 }


### PR DESCRIPTION
Implementation of Config cmd:
list
set
get

implemented key validation, save and load to file. 
Test coverage ditto/cmd/config - 80.4%